### PR TITLE
Install sudo

### DIFF
--- a/run-qemu.sh
+++ b/run-qemu.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+qemu-system-x86_64 \
+	-m size=2048 \
+	-nographic -no-reboot \
+	-kernel ./$(find output -iname "vmlinuz-*" | head -n 1) \
+	-initrd ./output/CentOs7_Lite_dev_$(cat VERSION)_fs.cpio.gz \
+	-append "console=ttyS0 init=/init root=/dev/ram0"
+

--- a/scripts/generate-image.sh
+++ b/scripts/generate-image.sh
@@ -102,6 +102,7 @@ yum --installroot=/centos7-builder/diskless-root -y install \
     gdb-gdbserver \
     tcpdump \
     ntp \
+	sudo \
     yum-cron \
     cronie 
 


### PR DESCRIPTION
Really small change per CATER-167925, sudo was not installed even though we had a correctly configued /etc/sudoers.

From Mike P:
> In CentOS 7 Lite, add sudo and fix the sudoers configuration to point to the correct path to chrt.

The sudoers configuration seems correct, I'm not seeing any issues with chrt. `sudo chrt`, `sudo /bin/chrt` `sudo /usr/bin/chrt` can all set/get policies fine. Running without sudo yields the typical `Operation not permitted` when trying to set policy.

Also added a script for testing this with QEMU. Of course, I will boot this on a real machine next week to verify that everything works as expected.