### PR TITLE
Allow laci, flaci and acctf to use reboot and poweroff

### DIFF
--- a/custom_files/sudoers
+++ b/custom_files/sudoers
@@ -1,3 +1,1 @@
-laci   ALL= NOPASSWD:  /usr/bin/chrt
-flaci  ALL= NOPASSWD:  /usr/bin/chrt
-acctf  ALL= NOPASSWD:  /usr/bin/chrt
+laci, flaci, acctf   ALL= NOPASSWD:  /usr/bin/chrt, /sbin/reboot, /sbin/poweroff


### PR DESCRIPTION
Allows these accounts to reboot/shutdown the machine.