### PR TITLE
Locale fixes

### DIFF
--- a/custom_files/sshd_config
+++ b/custom_files/sshd_config
@@ -1,0 +1,139 @@
+#	$OpenBSD: sshd_config,v 1.100 2016/08/15 12:32:04 naddy Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/bin:/usr/bin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+# If you want to change the port on a SELinux system, you have to tell
+# SELinux about this change.
+# semanage port -a -t ssh_port_t -p tcp #PORTNUMBER
+#
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+SyslogFacility AUTHPRIV
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+PermitRootLogin no
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+#PasswordAuthentication yes
+PermitEmptyPasswords yes
+PasswordAuthentication yes
+
+# Change to no to disable s/key passwords
+#ChallengeResponseAuthentication yes
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+#KerberosUseKuserok yes
+
+# GSSAPI options
+GSSAPIAuthentication yes
+GSSAPICleanupCredentials no
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+#GSSAPIEnablek5users no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+# WARNING: 'UsePAM no' is not supported in Red Hat Enterprise Linux and may cause several
+# problems.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#UsePrivilegeSeparation sandbox
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#ShowPatchLevel no
+#UseDNS yes
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# SLAC: Do not accept locale-related environment variables
+#AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+#AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+#AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
+AcceptEnv XMODIFIERS
+
+# override default of no subsystems
+Subsystem	sftp	/usr/libexec/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server

--- a/custom_files/sudoers
+++ b/custom_files/sudoers
@@ -1,1 +1,1 @@
-laci, flaci, acctf   ALL= NOPASSWD:  /usr/bin/chrt, /sbin/reboot, /sbin/poweroff
+laci, flaci, acctf   ALL= NOPASSWD:  /usr/bin/chrt, /sbin/reboot, /sbin/poweroff, /sbin/shutdown

--- a/run-qemu.sh
+++ b/run-qemu.sh
@@ -2,10 +2,25 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+IMAGE=./output/CentOs7_Lite_dev_$(cat VERSION)_fs.cpio.gz
+while test $# -gt 0; do
+	case $1 in
+	--prod)
+		IMAGE=./output/CentOs7_Lite_prod_$(cat VERSION)_fs.cpio.gz
+		shift
+		;;
+	*)
+		echo "Unknown arg $1"
+		exit 1
+		;;
+	esac
+done
+
 qemu-system-x86_64 \
 	-m size=2048 \
 	-nographic -no-reboot \
 	-kernel ./$(find output -iname "vmlinuz-*" | head -n 1) \
-	-initrd ./output/CentOs7_Lite_dev_$(cat VERSION)_fs.cpio.gz \
-	-append "console=ttyS0 init=/init root=/dev/ram0"
+	-initrd $IMAGE \
+	-append "console=ttyS0 init=/init root=/dev/ram0" \
+	-nic user,hostfwd=tcp::8022-:22
 

--- a/scripts/generate-image.sh
+++ b/scripts/generate-image.sh
@@ -126,6 +126,7 @@ cp -r /custom_files/epics.conf etc/security/limits.d
 cp -r /custom_files/90-nproc.conf etc/security/limits.d
 cp -r /custom_files/SLAC_properties etc/SLAC_properties
 cp -r /custom_files/sudoers etc/sudoers
+cp -f /custom_files/sshd_config etc/ssh/sshd_config
 
 # Set some important configuration
 if [ ! -e "init" ]; then

--- a/scripts/generate-image.sh
+++ b/scripts/generate-image.sh
@@ -164,12 +164,13 @@ sed -i "s/#DefaultLimitRTPRIO=/DefaultLimitRTPRIO=infinity/g" etc/systemd/user.c
 # chroot, set a blank password to root, and create the laci account. laci
 # account must have UID 8412 and be part of an lcls group with GID 2211.
 # The IDs are important for accessing NFS directories.
-# Activate NTP.
+# Activate NTP, generate required locales
 chroot . \
     bash -c '\
         /root/scripts/create-users.sh && \
         systemctl enable /usr/lib/systemd/system/run_bootfile.service && \
 	systemctl enable ntpd && \
+	localedef -i en_US -f UTF-8 en_US.utf8 && \
         exit \
     '
 

--- a/scripts/generate-image.sh
+++ b/scripts/generate-image.sh
@@ -161,6 +161,7 @@ sed -i "s/#DefaultLimitRTPRIO=/DefaultLimitRTPRIO=infinity/g" etc/systemd/system
 sed -i "s/#DefaultLimitMEMLOCK=/DefaultLimitMEMLOCK=infinity/g" etc/systemd/user.conf
 sed -i "s/#DefaultLimitRTPRIO=/DefaultLimitRTPRIO=infinity/g" etc/systemd/user.conf
 
+
 # chroot, set a blank password to root, and create the laci account. laci
 # account must have UID 8412 and be part of an lcls group with GID 2211.
 # The IDs are important for accessing NFS directories.
@@ -173,6 +174,10 @@ chroot . \
 	localedef -i en_US -f UTF-8 en_US.utf8 && \
         exit \
     '
+
+# Set the default locale. This matches the default on our DEV machines.
+echo "LANG=en_US.utf8" > etc/locale.conf
+
 
 # Generate ssh keys to avoid generating new ones every time the diskless
 # system boots, creating annoying RSA key mismatch error messages when


### PR DESCRIPTION
* Generate and default to en_US-utf8 locale. The current default was `POSIX` I believe, but that causes issues with SSH clients because they forward locale settings to the remote machine. On cpu-b15-rf02 we were seeing a lot of unhappy messages in the shell about this locale missing.
* Allow `shutdown` to be run passwordless via sudo. This is functionally identical to `poweroff`, so it should share the same behavior.
* Add --prod option to run-qemu and bridge port 22 -> 8022 to allow for testing on the guest with SSH

Closes #9 
