### PR TITLE
Fix mirrors and yum slowness

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,21 @@ cat /centos7-builder/diskless-root/etc/group
 ```
 
 Each directory in this repository has a README.md file that you can check to learn more about its contents.
+
+## Testing with QEMU
+
+A simple run-qemu.sh script is provided to test the image locally in QEMU. 
+
+`qemu-system-x86_64` must be available in your PATH for this to work. On Debian or Ubuntu, `qemu-system-x86_64` can be installed with `sudo apt install qemu-system`.
+
+
+To boot the image in QEMU:
+```sh
+./run-qemu.sh
+```
+
+The script bridges host port 8022 to guest port 22, so you can SSH in with the following command:
+```
+ssh -p 8022 laci@localhost
+```
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 # As of July 1st, 2024, mirrorlist.centos.org is gone and we need to switch to vault.centos.org
-RUN sed -i s,mirror.centos.org,mirror.stanford.edu,g /etc/yum.repos.d/CentOS-*.repo; \
+RUN sed -i s,mirror.centos.org,vault.centos.org,g /etc/yum.repos.d/CentOS-*.repo; \
     sed -i s,^#.*baseurl=http,baseurl=http,g /etc/yum.repos.d/CentOS-*.repo; \
     sed -i s,^mirrorlist=http,#mirrorlist=http,g /etc/yum.repos.d/CentOS-*.repo
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,10 @@ RUN sed -i s,mirror.centos.org,vault.centos.org,g /etc/yum.repos.d/CentOS-*.repo
     sed -i s,^#.*baseurl=http,baseurl=http,g /etc/yum.repos.d/CentOS-*.repo; \
     sed -i s,^mirrorlist=http,#mirrorlist=http,g /etc/yum.repos.d/CentOS-*.repo
 
-# Install packages we will need in our 'builder' OS
-RUN yum -y updateinfo && \
+# Install packages we will need in our 'builder' OS.
+# NOTE: Default ulimit is insanely high and causes yum to slow to a crawl
+RUN ulimit -n 1024 && \
+    yum -y update && \
     yum install -y \
         wget \
         yumdownloader \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,12 @@
 FROM centos:7
 
+# As of July 1st, 2024, mirrorlist.centos.org is gone and we need to switch to vault.centos.org
+RUN sed -i s,mirror.centos.org,mirror.stanford.edu,g /etc/yum.repos.d/CentOS-*.repo; \
+    sed -i s,^#.*baseurl=http,baseurl=http,g /etc/yum.repos.d/CentOS-*.repo; \
+    sed -i s,^mirrorlist=http,#mirrorlist=http,g /etc/yum.repos.d/CentOS-*.repo
+
 # Install packages we will need in our 'builder' OS
-RUN yum -y update && \
+RUN yum -y updateinfo && \
     yum install -y \
         wget \
         yumdownloader \

--- a/generate.sh
+++ b/generate.sh
@@ -5,6 +5,7 @@ cd docker && ./build.sh && cd -
 
 # Use the docker image to build the CentOS7 diskless images
 docker container run -ti --rm \
+    --ulimit "nofile=1024:1024" \
     --mount src=${PWD}/output,target=/output,type=bind \
     --mount src=centos7-builder,target=/centos7-builder,type=volume \
     --mount src=${PWD}/scripts,target=/scripts,type=bind \

--- a/scripts/generate-image.sh
+++ b/scripts/generate-image.sh
@@ -70,6 +70,11 @@ fi
 # centos-release contains things like the yum configs, and is necessary to bootstrap the system
 rpm --root=/centos7-builder/diskless-root -ivh --nodeps centos-release-7-9.2009.1.el7.centos.x86_64.rpm
 
+# Switch to Stanford mirrors now that mirror.centos.org is offline
+sed -i s,mirror.centos.org,mirror.stanford.edu,g /centos7-builder/diskless-root/etc/yum.repos.d/CentOS-*.repo
+sed -i s,^#.*baseurl=http,baseurl=http,g /centos7-builder/diskless-root/etc/yum.repos.d/CentOS-*.repo
+sed -i s,^mirrorlist=http,#mirrorlist=http,g /centos7-builder/diskless-root/etc/yum.repos.d/CentOS-*.repo
+
 # Add Intel network card drivers for Dell R750 servers
 RPMs="./Intel_LAN_drivers_Dell_R750/*.rpm"
 for f in $RPMs


### PR DESCRIPTION
Fixes a couple of things.

Mirrors: use vault.centos.org instead of the old CentOS 7 mirrors that were taken offline

Yum slowness: Change ulimit -n to 1024. Otherwise yum slows to a crawl. For some reason ulimit -n shows >1 million by default...

This fixes the image not being able to build as of July.