### PR TITLE
Force yum to download centos-release version 7.9.2009.1 instead of .2

### DIFF
--- a/scripts/generate-image.sh
+++ b/scripts/generate-image.sh
@@ -64,7 +64,7 @@ cd /centos7-builder
 # Download centos-release, if needed
 if [ ! -f "centos-release-7-9.2009.1.el7.centos.x86_64.rpm" ]; then
   # Get the centos-release RPM
-  yumdownloader centos-release
+  yumdownloader centos-release-7-9.2009.1.el7.centos
 fi
 
 # centos-release contains things like the yum configs, and is necessary to bootstrap the system


### PR DESCRIPTION
This fixes the version of `centos-release` to 7.9.2009.1. Without this, `yumdownloader` retrieves `centos-release-7-9.2009.2.el7.centos.x86_64.rpm`, breaking the script.