### PR TITLE
Add GitHub CI/CD configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build + Release
+
+on:
+  push:
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Generate DEV image
+      run: ./generate.sh
+
+    - name: Generate PROD image
+      run: ./generate.sh --prod
+
+    - name: Get Version
+      id: version
+      run: echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+
+    # Create a new draft release if we're pushing to a tag
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      # Only run this when we push to a tag
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          output/*.gz
+          output/vmlinuz*
+        draft: true
+

--- a/generate.sh
+++ b/generate.sh
@@ -4,7 +4,7 @@
 cd docker && ./build.sh && cd -
 
 # Use the docker image to build the CentOS7 diskless images
-docker container run -ti --rm \
+docker container run -i --rm \
     --ulimit "nofile=1024:1024" \
     --mount src=${PWD}/output,target=/output,type=bind \
     --mount src=centos7-builder,target=/centos7-builder,type=volume \


### PR DESCRIPTION
Adds a GitHub actions configuration that tests the PROD and DEV image builds in CI.

When a new version is tagged, it will generate a draft release with the images attached. 