### PR TITLE
Disable NICs on boot

### DIFF
--- a/custom_files/disable_disconnected_nics.service
+++ b/custom_files/disable_disconnected_nics.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Disable disconnected network interfaces on boot
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/root/scripts/disable_disconnected_nics.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/custom_files/disable_disconnected_nics.sh
+++ b/custom_files/disable_disconnected_nics.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get a list of all network interfaces (excluding loopback)
+interfaces=$(ls /sys/class/net | grep -v lo)
+
+for iface in $interfaces; do
+        # Check if the interface is disconnected (carrier detected)
+        if [[ -f "/sys/class/net/$iface/carrier" ]] && [[ "$(cat /sys/class/net/$iface/carrier)" == "0" ]]; then
+            ip link set dev $iface down
+        fi
+done


### PR DESCRIPTION
The idea is to have a service that will run the script after the network is set up. The script checks for all NICs that don't have an Ethernet connection and disables them.

Tested in cpu-b34-test1, but still needs more tests from Minh Vu to make sure we didn't break anything.

@pnispero, this is a new requirement from Ken Brobeck that you might cherry-pick to the Rocky 9 branch.