### PR TITLE
tell systemd to output run_bootfile service to console and journald

### DIFF
--- a/custom_files/run_bootfile_dev.service
+++ b/custom_files/run_bootfile_dev.service
@@ -5,6 +5,9 @@ After=network-online.target
 [Service]
 Type=simple
 ExecStart = /root/scripts/run_bootfile_dev.sh
+StandardOutput=journal+console
+StandardError=inherit
+TTYPath=/dev/tty1
 
 [Install]
 WantedBy = default.target

--- a/custom_files/run_bootfile_prod.service
+++ b/custom_files/run_bootfile_prod.service
@@ -5,6 +5,9 @@ After=network-online.target
 [Service]
 Type=simple
 ExecStart = /root/scripts/run_bootfile_prod.sh
+StandardOutput=journal+console
+StandardError=inherit
+TTYPath=/dev/tty1
 
 [Install]
 WantedBy = default.target


### PR DESCRIPTION
The user will see messages on the first TTY, which in our case is /dev/ttyS0, but can also be the physical monitor's initial login screen.  These messages would typically be SLAC's st.cmd commands.

When we converted to use systemd, these messages disappeared into journald.  This change restores them.